### PR TITLE
Updated how settings loading and saving is handled (and fixed a stupid mistake I made)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ See the full [LICENSE](./LICENSE) file for details.
 BASH:
 ```
 # to build
-git clone https://github.com/RiverDewberry/Abstract.git
+git clone https://github.com/Lanse0123/Abstract.git
 cd Abstract
 ./gradlew build
 ./gradlew shadowJar

--- a/src/main/java/lanse/abstractt/core/screens/SettingsScreen.java
+++ b/src/main/java/lanse/abstractt/core/screens/SettingsScreen.java
@@ -88,8 +88,11 @@ public class SettingsScreen extends JPanel {
 
         DisplayModeSelector.displayMode = (DisplayModeSelector.DisplayMode) displayModeSelector.getSelectedItem();
 
-        Settings.save(); // Save to file
-        JOptionPane.showMessageDialog(this, "Settings saved!", "Success", JOptionPane.INFORMATION_MESSAGE);
+        if(Settings.save()) // Attempt save to file
+            JOptionPane.showMessageDialog(this, "Settings saved!", "Success", JOptionPane.INFORMATION_MESSAGE);
+        else
+            JOptionPane.showMessageDialog(this, "Settings unable to be saved.", "Error", JOptionPane.INFORMATION_MESSAGE);
+
         returnToMainMenu();
     }
 

--- a/src/main/java/lanse/abstractt/storage/Settings.java
+++ b/src/main/java/lanse/abstractt/storage/Settings.java
@@ -23,6 +23,10 @@ public class Settings {
     // Load settings from JSON
     public static void load() {
         try (BufferedReader reader = new BufferedReader(new FileReader(SETTINGS_PATH))) {
+
+            //added this line to show where to find settings file
+            System.out.println("Settings file found at " + SETTINGS_PATH + " .");
+
             StringBuilder jsonContent = new StringBuilder();
             String line;
             while ((line = reader.readLine()) != null) {
@@ -51,13 +55,24 @@ public class Settings {
 
             //////////////////////////////////////////////////////////////////////////////////////////////////////////////
         } catch (IOException e) {
+
+            //provides clearer messages
+            File settingsFile = new File(SETTINGS_PATH);
+            if(!settingsFile.exists())
+                System.out.print("No settings file found at " + SETTINGS_PATH + " . ");
+            else if (settingsFile.isDirectory())
+                //this error message can happen, since "settings.json" is a valid directory name on linux 
+                System.out.print("File found at settings path ( " + SETTINGS_PATH + " ) but is a directory. ");
+            else
+                System.out.print("Error while reading settings file ( " + SETTINGS_PATH + " ). ");
+
             // No settings file yet? Just use defaults.
-            System.out.println("No settings file found. Using default settings.");
+            System.out.println("Using default settings.");
         }
     }
 
-    // Save settings to disk
-    public static void save() {
+    // Save settings to disk. returns true if settings could be saved, otherwise returns false
+    public static boolean save() {
         try {
             if (!Files.exists(SETTINGS_DIR)) {
                 Files.createDirectories(SETTINGS_DIR);
@@ -79,8 +94,27 @@ public class Settings {
             try (FileWriter file = new FileWriter(SETTINGS_PATH)) {
                 file.write(json.toString(4));
             }
+
+            //validates that settings were saved
+            try (BufferedReader reader = new BufferedReader(new FileReader(SETTINGS_PATH))) {
+                StringBuilder jsonContent = new StringBuilder();
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    jsonContent.append(line);
+                }
+
+                JSONObject savedJson = new JSONObject(jsonContent.toString());
+
+                return savedJson.toString(4).equals(json.toString(4));
+
+            } catch (IOException e) {
+                System.out.println("Unable to save settings ( " + SETTINGS_PATH + " ).");
+                return false;
+            }
+
         } catch (IOException e) {
             e.printStackTrace();
+            return false;
         }
     }
 


### PR DESCRIPTION
When settings fail to load, there is now a more clear message about what happened. Settings.java also now checks if settings get saved correctly when attempting to save settings. The popup that SettingsScreen.java shows when attempting to save settings is now dependent on settings getting saved correctly.